### PR TITLE
increase RAM to 2G to be able to boot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ RELEASE ?= stable
 DIGEST_URL ?= https://$(RELEASE).release.core-os.net/amd64-usr/current/coreos_production_iso_image.iso.DIGESTS
 CONFIG ?= container-linux-config.yml
 DISK_SIZE ?= 40000
-MEMORY ?= 1024M
+MEMORY ?= 2048M
 BOOT_WAIT ?= 45s
 
 container-linux: builds/container-linux-$(RELEASE).qcow2

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ RELEASE ?= alpha
 DIGEST_URL ?= https://$(RELEASE).release.core-os.net/amd64-usr/current/coreos_production_iso_image.iso.DIGESTS
 CONFIG ?= container-linux-config.yml
 DISK_SIZE ?= 40000
-MEMORY ?= 1024M
+MEMORY ?= 2048M
 BOOT_WAIT ?= 45s
 ```
 ### Basic example using defaults
@@ -71,7 +71,7 @@ Without buidling from the Makefile you will neet to obtain the iso checksum manu
 "iso_checksum": "",
 "iso_checksum_type": "none",
 "disk_size": "40000",
-"memory": "1024M",
+"memory": "2048M",
 "boot_wait": "45s",
 "ignition": "ignition.json"
 ```

--- a/container-linux.json
+++ b/container-linux.json
@@ -4,7 +4,7 @@
         "iso_checksum": "",
         "iso_checksum_type": "none",
         "disk_size": "40000",
-        "memory": "1024M",
+        "memory": "2048M",
         "boot_wait": "45s",
         "ignition": "ignition.json"
     },


### PR DESCRIPTION
With the default RAM 1G, after the default Container Linux iso image got unpacked, the Qemu VM fails to boot with an error message `Failed to switch root`. Thus it's not possible at all to proceed installation.

In these days, it's fairly reasonable to set the default RAM to 2G in most cases. So let's increase the default RAM to 2G.